### PR TITLE
Add ShopSavvy for Bluesky

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -75,6 +75,7 @@ For more Bluesky tools, check [Awesome Bluesky](https://github.com/notjuliet/awe
 ## Tools
 
 * [ATFile](https://github.com/ziodotsh/atfile) - Store and retrieve files on the ATmosphere.
+* [ShopSavvy for Bluesky](https://github.com/shopsavvy/bluesky-shopsavvy) - AT Protocol suite: reactive mention bot for real-time price lookups, a custom deals feed generator, and a daily deal poster.
 
 ## Lexicons
 


### PR DESCRIPTION
Adds [ShopSavvy for Bluesky](https://github.com/shopsavvy/bluesky-shopsavvy) to the **Tools** section.

An AT Protocol suite built around the ShopSavvy Data API:

- **Mention bot** that watches the Jetstream firehose for `@shopsavvy.bsky.social` and replies with real-time price comparisons across retailers
- **Custom feed generator** that surfaces deal-relevant posts from across Bluesky, scored by recency, engagement, and retailer URL signals
- **Daily deal poster** that publishes the top deal as an image+text post every morning